### PR TITLE
tjs-335 - adding MSAL-Legrand 

### DIFF
--- a/MSAL-Legrand/0.4.2.1/MSAL-Legrand.podspec
+++ b/MSAL-Legrand/0.4.2.1/MSAL-Legrand.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL-Legrand"
-  s.version      = "0.4.2"
+  s.version      = "0.4.2.1"
   s.summary      = "Microsoft Authentication Library (MSAL) Preview for iOS"
 
   s.description  = <<-DESC

--- a/MSAL-Legrand/0.4.2/MSAL-Legrand.podspec
+++ b/MSAL-Legrand/0.4.2/MSAL-Legrand.podspec
@@ -1,0 +1,51 @@
+Pod::Spec.new do |s|
+  s.name         = "MSAL-Legrand"
+  s.version      = "0.4.2"
+  s.summary      = "Microsoft Authentication Library (MSAL) Preview for iOS"
+
+  s.description  = <<-DESC
+                   The MSAL library preview for iOS gives your app the ability to begin using the Microsoft Cloud by supporting Microsoft Azure Active Directory and Microsoft Accounts in a converged experience using industry standard OAuth2 and OpenID Connect. The library also supports Microsoft Azure B2C for those using our hosted identity management service.  Contains changes for Legrand that exposes the refresh key.
+                   DESC
+  s.homepage     = "https://www.legrand.us"
+  s.license      = 'Proprietary'
+  s.platform     = :ios, :osx
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.11"
+  s.source       = { 
+    :git => "https://github.com/legrand-home-systems-mdt/microsoft-authentication-library-for-objc.git",
+    :tag => s.version.to_s,
+    :submodules => true
+  }
+
+  s.pod_target_xcconfig = { 'CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF' => 'NO' }
+  s.default_subspecs ='app-lib'
+  
+  s.prefix_header_file = "MSAL/src/MSAL.pch"
+  s.header_dir = "MSAL"
+
+  s.subspec 'app-lib' do |app|
+  	app.source_files = "MSAL/src/**/*.{h,m}", "MSAL/IdentityCore/IdentityCore/src/**/*.{h,m}"
+  	app.ios.public_header_files = "MSAL/src/public/*.h","MSAL/src/public/ios/*.h", "MSAL/src/public/configuration/**/*.h"
+  	app.osx.public_header_files = "MSAL/src/public/mac/*.h","MSAL/src/public/*.h", "MSAL/src/public/configuration/**/*.h"
+  
+  	app.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
+  		
+  	app.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
+  	app.requires_arc = true
+  end
+  
+  # Note, MSAL has limited support for running in app extensions.
+  s.subspec 'extension' do |ext|
+  	ext.compiler_flags = '-DADAL_EXTENSION_SAFE=1'
+  	ext.source_files = "MSAL/src/**/*.{h,m}", "MSAL/IdentityCore/IdentityCore/src/**/*.{h,m}"
+  	ext.ios.public_header_files = "MSAL/src/public/*.h","MSAL/src/public/ios/*.h", "MSAL/src/public/configuration/**/*.h"
+  	ext.osx.public_header_files = "MSAL/src/public/mac/*.h","MSAL/src/public/*.h", "MSAL/src/public/configuration/**/*.h"
+  
+  	# There is currently a bug in CocoaPods where it doesn't combine the public headers
+  	# for both the platform and overall.
+  	ext.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
+  	ext.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
+  	
+  	ext.requires_arc = true
+  end
+end


### PR DESCRIPTION
which is a fork of the MSAL library with the refresh token exposed.